### PR TITLE
Align nextcloud's container gid and uid to host

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -5,7 +5,8 @@ ARG version_php
 ARG version_xdebug
 ARG version_node
 ARG version_jsignpdf
-
+ARG host_uid
+ARG host_gid
 ENV VERSION_XDEBUG=${version_xdebug}
 ENV VERSION_NODE=${version_node}
 ENV VERSION_JSIGNPDF=${version_jsignpdf}
@@ -21,6 +22,10 @@ RUN apt-get install -y \
         unzip \
         && docker-php-ext-install opcache \
         && docker-php-ext-install zip
+
+RUN usermod --non-unique --uid ${host_uid} www-data \
+  && groupmod --non-unique --gid ${host_gid} www-data 
+
 
 # Install PostgreSQL
 RUN apt-get install -y \

--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ DEFAULT_PHONE_REGION=UTC
 XDEBUG_CONFIG=client_host=172.17.0.1 client_port=9003 start_with_request=yes
 
 TZ=America/Sao_Paulo
+
+UID=1000
+GID=1000

--- a/README.md
+++ b/README.md
@@ -26,11 +26,5 @@ After finish the setup, access this url: http://localhost/.
 
 ## Start development of apps
 
-You will need create (or clone) the folder of the app that you will work inside the folder `volumes/nextcloud/apps`. Because the owner of folder `apps` is the root user, you will need do the follow steps (using LibreSign app repository as example) to change the owner of folder `apps` to your user and group, clone the app and revert the owner of folder app to root again:
-
-```bash
-sudo chown $USER:$USER volumes/nextcloud/apps
-git clone git@github.com:LibreSign/libresign.git volumes/nextcloud/apps/libresign
-sudo chown www-data:www-data volumes/nextcloud/apps
-```
+You will need create (or clone) the folder of the app that you will work inside the folder `volumes/nextcloud/apps`. 
 Good work!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
         version_xdebug: ${VERSION_XDEBUG}
         version_node: ${VERSION_NODE}
         version_jsignpdf: ${VERSION_JSIGNPDF}
+        host_uid: ${UID}
+        host_gid: ${GID}
     volumes:
       - ./.docker/app/wait-for-db.php:/var/www/scripts/wait-for-db.php
       - ./.env:/var/www/.env


### PR DESCRIPTION
Made nextcloud container www-data user's UID and GID configurable via envfile so changing the directory ownership while developing is no more needed and developer's activity is smoother.