### PR TITLE
Remove unused port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
         version_node: ${VERSION_NODE}
         host_uid: ${UID}
         host_gid: ${GID}
-    ports:
-      - 127.0.0.1:8080:8080
     volumes:
       - ./.docker/app/wait-for-db.php:/var/www/scripts/wait-for-db.php
       - ./.env:/var/www/.env


### PR DESCRIPTION
This port mapping is specific to make possible access the documentation page of LbireSign. Since that this project is a generic project to work with Nextcloud, don't make sense to have this port mapping.

I recommend to all developers that want any type of customizations over this docker-compose.yml, using extends:
https://docs.docker.com/compose/extends/#extending-services