### PR TITLE
Simplify cron execution

### DIFF
--- a/.docker/app/cron.sh
+++ b/.docker/app/cron.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-set -eu
-exec busybox crond -f -l 0 -L /dev/stdout

--- a/.docker/app/entrypoint.sh
+++ b/.docker/app/entrypoint.sh
@@ -67,5 +67,9 @@ EOF
     runuser -u www-data -- php occ config:app:set core backgroundjobs_mode      --value "cron"
 fi
 
+# Run cron
+exec busybox crond -f -l 0 -L /dev/stdout > /dev/null 2>&1 &
+runuser -u www-data -- php -f /var/www/html/cron.php
+
 # Start PHP-FPM
 php-fpm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,19 +60,6 @@ services:
       - VERSION_NEXTCLOUD
       - AUTOINSTALL
       - XDEBUG_CONFIG
-  cron:
-    build:
-      context: .docker/app
-      args:
-        version_php: ${VERSION_PHP}
-        version_node: ${VERSION_NODE}
-        host_uid: ${UID}
-        host_gid: ${GID}
-    volumes:
-      - ./.docker/app/wait-for-db.php:/var/www/scripts/wait-for-db.php
-      - ./.env:/var/www/.env
-      - ./volumes/nextcloud:/var/www/html
-    entrypoint: /usr/local/bin/cron.sh
   nginx:
     build: .docker/web
     restart: unless-stopped


### PR DESCRIPTION
Removed the extra service to run cron and added the execution at `entrypoint.sh` file of php service.