### PR TITLE
Fix permission at home of user www-data

### DIFF
--- a/.docker/Dockerfile.php80
+++ b/.docker/Dockerfile.php80
@@ -44,13 +44,16 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
     xdebug \
     zip \
     && rm /usr/local/bin/install-php-extensions \
-    && sed -i'' 's|.*<policy domain="coder".*"PDF".*|<policy domain="coder" rights="read \| write" pattern="PDF" />|g' /etc/ImageMagick-6/policy.xml
+    # make possible ImageMagic handle PDF files
+    && sed -i'' 's|.*<policy domain="coder".*"PDF".*|<policy domain="coder" rights="read \| write" pattern="PDF" />|g' /etc/ImageMagick-6/policy.xml \
+    # pevent errors when try to create files at /var/www with user www-data
+    && chown -R www-data /var/www
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-
 COPY config/php/* /usr/local/etc/php/conf.d/
-
-WORKDIR /var/www/html
 COPY scripts/* /var/www/scripts/
 COPY bin/* /usr/local/bin/
+
+WORKDIR /var/www/html
+
 ENTRYPOINT [ "bash", "/var/www/scripts/entrypoint.sh" ]


### PR DESCRIPTION
The user `www-data` by default haven't a home folder and neither permission to write at `/var/www` folder. Because now is possible login with this user, is necessary to him to have permission at folder `/var/www`.

This problem was identified when I tried to run psalm at LibreSign and identified that psalm write at `~/.cache` folder, but the user www-data haven't permission by default to write at `/var/www` folder.

Reference: https://psalm.dev/docs/running_psalm/configuration/#cachedirectory