### PR TITLE
Remove unecessary environment

### DIFF
--- a/.docker/scripts/entrypoint.sh
+++ b/.docker/scripts/entrypoint.sh
@@ -14,9 +14,6 @@ if [ ! -d ".git" ]; then
     chown -R www-data:www-data .
 fi
 
-# Disable xdebug only at scope of this script
-export XDEBUG_MODE=off
-
 # Wait for database
 php /var/www/scripts/wait-for-db.php
 


### PR DESCRIPTION
This environment was used before define xebug.log_level to zero to prevent display warnings from xdebug. With log_level = 0 is unecessary use this environment and other point is because the php-fpm at end of this entrypoint is started with value of this environment.