### PR TITLE
chore: bump minumum PHP version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - MYSQL_USER=${MYSQL_USER:-nextcloud}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-nextcloud}
   nextcloud:
-    image: ghcr.io/librecodecoop/nextcloud-dev-php${PHP_VERSION:-81}:latest
+    image: ghcr.io/librecodecoop/nextcloud-dev-php${PHP_VERSION:-82}:latest
     # build:
     #   context: .docker/
     #   dockerfile: Dockerfile.php${PHP_VERSION:-81}


### PR DESCRIPTION
Fallback of:
`https://github.com/nextcloud/server/commit/122cd68d56f37f86a27ecbab7ff4de94f50d2fb5`