### PR TITLE
chore: Update Node.js to version 22 for Nextcloud 32+ compatibility

### DIFF
--- a/.docker/Dockerfile.php82
+++ b/.docker/Dockerfile.php82
@@ -59,8 +59,8 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
     && export NVM_DIR="/root/.nvm" \
     && . "$NVM_DIR/nvm.sh" \
-    && nvm install 20 \
-    && nvm alias default 20
+    && nvm install 22 \
+    && nvm alias default 22
 
 COPY config/php/* /usr/local/etc/php/conf.d/
 COPY scripts/* /var/www/scripts/

--- a/.docker/Dockerfile.php83
+++ b/.docker/Dockerfile.php83
@@ -59,8 +59,8 @@ RUN chmod uga+x /usr/local/bin/install-php-extensions && sync \
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash \
     && export NVM_DIR="/root/.nvm" \
     && . "$NVM_DIR/nvm.sh" \
-    && nvm install 20 \
-    && nvm alias default 20
+    && nvm install 22 \
+    && nvm alias default 22
 
 COPY config/php/* /usr/local/etc/php/conf.d/
 COPY scripts/* /var/www/scripts/


### PR DESCRIPTION
Update Node.js from version 20 to 22 in both PHP 8.2 and PHP 8.3 Dockerfiles to comply with Nextcloud 32+ minimum stable requirements.