### PR TITLE
fix: incomplete setup don't stop a new setup

### DIFF
--- a/.docker/scripts/nextcloud-entrypoint.sh
+++ b/.docker/scripts/nextcloud-entrypoint.sh
@@ -24,6 +24,12 @@ php /var/www/scripts/wait-for-db.php
 
 install_cmd_status=0
 
+# An empty or incomplete config.php (interrupted install) must not block a new installation
+if [[ -f "config/config.php" ]] && ! grep -qE "'installed'[[:space:]]*=>[[:space:]]*true" config/config.php; then
+    echo "⚠️  Found an empty or incomplete config/config.php. Removing it to install from scratch."
+    rm -f config/config.php
+fi
+
 # Set configurations, if needed
 if [[ ! -f "config/config.php" && ${AUTOINSTALL} -eq 1 ]]; then
     echo "⌛️ Starting installation ..."


### PR DESCRIPTION
If have some error during start environment and the config/config.php is empty, the start will get a loop as the follow log:

nextcloud-1  | ⌛ Waiting for database 🐬mysql
nextcloud-1  | ✅ Database 🐬mysql ready
nextcloud-1  | Nextcloud is not installed - only a limited number of commands are available nextcloud-1  | ❌ Nextcloud is not installed. Skipping startup tasks and stopping container. nextcloud-1 exited with code 1
nextcloud-1  | ⌛ Waiting for database 🐬mysql
nextcloud-1  | ✅ Database 🐬mysql ready
nextcloud-1  | Nextcloud is not installed - only a limited number of commands are available nextcloud-1  | ❌ Nextcloud is not installed. Skipping startup tasks and stopping container. nextcloud-1 exited with code 1
nextcloud-1  | ⌛ Waiting for database 🐬mysql
nextcloud-1  | ✅ Database 🐬mysql ready
nextcloud-1  | Nextcloud is not installed - only a limited number of commands are available nextcloud-1  | ❌ Nextcloud is not installed. Skipping startup tasks and stopping container. nextcloud-1 exited with code 1
nextcloud-1  | ⌛ Waiting for database 🐬mysql
nextcloud-1  | ✅ Database 🐬mysql ready
nextcloud-1  | Nextcloud is not installed - only a limited number of commands are available nextcloud-1  | ❌ Nextcloud is not installed. Skipping startup tasks and stopping container. nextcloud-1 exited with code 1
nextcloud-1  | ⌛ Waiting for database 🐬mysql
nextcloud-1  | ✅ Database 🐬mysql ready
nextcloud-1  | Nextcloud is not installed - only a limited number of commands are available nextcloud-1  | ❌ Nextcloud is not installed. Skipping startup tasks and stopping container. nextcloud-1 exited with code 1
nextcloud-1  | ⌛ Waiting for database 🐬mysql
nextcloud-1  | ✅ Database 🐬mysql ready
nextcloud-1  | Nextcloud is not installed - only a limited number of commands are available nextcloud-1  | ❌ Nextcloud is not installed. Skipping startup tasks and stopping container. nextcloud-1 exited with code 1
nextcloud-1  | ⌛ Waiting for database 🐬mysql
nextcloud-1  | ✅ Database 🐬mysql ready
nextcloud-1  | Nextcloud is not installed - only a limited number of commands are available nextcloud-1  | ❌ Nextcloud is not installed. Skipping startup tasks and stopping container. nextcloud-1 exited with code 1