### PR TITLE
feat: publish version-tagged PHP images for Dependabot

### DIFF
--- a/.github/workflows/docker-php.yml
+++ b/.github/workflows/docker-php.yml
@@ -23,6 +23,13 @@ jobs:
           - php81
           - php82
           - php83
+        include:
+          - container: php81
+            version: '8.1'
+          - container: php82
+            version: '8.2'
+          - container: php83
+            version: '8.3'
     permissions:
       packages: write
       contents: read
@@ -77,6 +84,8 @@ jobs:
           tags: |
             ghcr.io/librecodecoop/nextcloud-dev-${{ matrix.container }}:${{ github.sha }}
             ghcr.io/librecodecoop/nextcloud-dev-${{ matrix.container }}:latest
+            ghcr.io/librecodecoop/nextcloud-dev:${{ matrix.version }}
+            ghcr.io/librecodecoop/nextcloud-dev:${{ matrix.version }}-${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache


### PR DESCRIPTION
Closes #123

## Changes

Publish a version-tagged image from the same build matrix, **in addition to** the existing names (nothing currently published changes):

- `ghcr.io/librecodecoop/nextcloud-dev:8.1`, `:8.2`, `:8.3`
- `ghcr.io/librecodecoop/nextcloud-dev:<version>-<sha>` for pinning

With the PHP version in the *tag* instead of the image *name*, consumers (e.g. `LibreSign/libresign`'s devcontainer) can reference a literal tag like `nextcloud-dev:8.3` and add a `docker` ecosystem entry to their `dependabot.yml` — Dependabot then opens the bump PR automatically whenever a new PHP version image is published here. That is not possible today because Dependabot never rewrites image names, only version-like tags (see #123 for details).

## Notes for maintainers

- The first push to `main` will create the new `nextcloud-dev` package on GHCR as **private** by default — it needs its visibility set to public once.
- Existing consumers keep working unchanged: `nextcloud-dev-php8X:latest` / `:<sha>` continue to be published from the same build (same digest, extra tags only).
- Follow-up on the consumer side: LibreSign/libresign#8033 switches the devcontainer to `nextcloud-dev:8.3` + Dependabot config.

Assisted-by: Claude Code:claude-fable-5
